### PR TITLE
Fix flaky bug

### DIFF
--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketDataTest.java
@@ -64,7 +64,7 @@ public class ExtendedScenarioMarketDataTest {
     assertThat(test.findValue(ID2)).isEqualTo(Optional.of(VAL2));
     assertThat(test.findValue(ID3)).isEqualTo(Optional.of(VAL3));
     assertThat(test.findValue(ID4)).isEqualTo(Optional.empty());
-    assertThat(test.getIds()).containsExactly(ID1, ID2, ID3);
+    assertThat(test.getIds()).containsExactlyInAnyOrder(ID1, ID2, ID3);
     assertThat(test.findIds(ID1.getMarketDataName())).isEqualTo(ImmutableSet.of(ID1));
     assertThat(test.findIds(ID3.getMarketDataName())).isEqualTo(ImmutableSet.of(ID3));
     assertThat(test.getTimeSeries(ID4)).isEqualTo(TIME_SERIES);
@@ -82,7 +82,7 @@ public class ExtendedScenarioMarketDataTest {
     assertThat(test.getValue(ID1)).isEqualTo(VAL3);
     assertThat(test.getValue(ID2)).isEqualTo(VAL2);
     assertThatExceptionOfType(MarketDataNotFoundException.class).isThrownBy(() -> test.getValue(ID3));
-    assertThat(test.getIds()).containsExactly(ID1, ID2);
+    assertThat(test.getIds()).containsExactlyInAnyOrder(ID1, ID2);
     assertThat(test.findValue(ID1)).isEqualTo(Optional.of(VAL3));
     assertThat(test.findValue(ID2)).isEqualTo(Optional.of(VAL2));
     assertThat(test.findValue(ID3)).isEqualTo(Optional.empty());

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -229,6 +229,11 @@
           </properties>
         </configuration>
       </plugin>
+	  <plugin>
+        <groupId>edu.illinois</groupId>
+        <artifactId>nondex-maven-plugin</artifactId>
+        <version>1.1.2</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -229,11 +229,6 @@
           </properties>
         </configuration>
       </plugin>
-	  <plugin>
-        <groupId>edu.illinois</groupId>
-        <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.2</version>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
1. The failed flaky test
- The project is built and tested under `javaJDK8`.
- The tool used for the flaky test detection is NonDex, information for which can be found here. -> [NonDex](https://github.com/TestingResearchIllinois/NonDex)
- I ran `mvn -pl data edu.illinois:nondex-maven-plugin:1.1.2:debug -Dtest=com.opengamma.strata.data.scenario.ExtendedScenarioMarketDataTest` under the directory `Strata/modules`, which produces
`java.lang.AssertionError: 
Actual and expected have the same elements but not in the same order, at index 0 actual element was: 2
whereas expected element was: 1
at com.opengamma.strata.data.scenario.ExtendedScenarioMarketDataTest.of_addition(ExtendedScenarioMarketDataTest.java:67)`
and
`java.lang.AssertionError: 
Actual and expected have the same elements but not in the same order, at index 0 actual element was: 2
whereas expected element was: 1
at com.opengamma.strata.data.scenario.ExtendedScenarioMarketDataTest.of_override(ExtendedScenarioMarketDataTest.java:85)`.

2. Why the tests failed
- In the implementation of the function `com.opengamma.strata.data.scenario.ExtendedScenarioMarketData.getIds()` in `Strata/blob/main/modules/data/src/main/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketData.java`, the construction of the returned immutable set utilizes `com.google.common.collect.ImmutableSet.Builder.addAll()` and `com.google.common.collect.ImmutableSet.Builder.add()`, which doesn't guarantee the order of the elements added.

3. The changes made
- Here we change the `containExactly` to `containExactlyInAnyOrder` in the corresponding two test modules in the test class `ExtendedScenarioMarketDataTest`.